### PR TITLE
Fixed writing values with spaces

### DIFF
--- a/src/Writer/File/EnvFileWriter.php
+++ b/src/Writer/File/EnvFileWriter.php
@@ -25,6 +25,10 @@ class EnvFileWriter implements WriterInterface
             $prefix = PHP_EOL;
         }
 
+        if (strpos($value, ' ') !== false && strpos($value, '"') === false) {
+            $value = '"' . $value . '"';
+        }
+
         file_put_contents($resource, $prefix . $key . '=' . $value, FILE_APPEND);
     }
 }


### PR DESCRIPTION
I discovered that the "sync" command has troubles syncing keys when there are spaces in values.

For example: (in .env.example)
`TEXT_COMPANY_NAME="My Company"`
should be written to .env as:
`TEXT_COMPANY_NAME="My Company"`
but instead is written as:
`TEXT_COMPANY_NAME=My Company`

This raises an error as spaces in values are not allowed in .env files unless they are surronded by ".