### PR TITLE
Add the ability to send slack notifications when `env:check` fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Keep your .env in sync with your .env.example or vice versa.
 
-It reads the .env.example file and makes suggestions to fill your .env accordingly. 
+It reads the .env.example file and makes suggestions to fill your .env accordingly.
 
 ## Installation via Composer
 
@@ -37,9 +37,11 @@ If you use the `--no-interaction` flag, the command will copy all new keys with 
 
 You can check if your .env is missing some variables from your .env.example by using the `php artisan env:check` command.
 
-The command simply show you which keys are not present in your .env file. This command will return 0 if your files are in sync, and 1 if they are not, so you can use this in a script
+The command simply show you which keys are not present in your .env file. This command will return 0 if your files are in sync, and 1 if they are not, so you can use this in a script.
 
 Again, you can launch the command with the option `--reverse` or with `--src` and `--dest`.
+
+If you want to use the command after deployment to check, if any `.env` variables are missing, you can pass the `--notifySlack` flag. In case you are missing some variable message will be sent to slack using `ENV_SYNC_SLACK_URL`. You can also customize the channel using `ENV_SYNC_SLACK_CHANNEL` or you can publish all the configs with `php artisan vendor:publish` and customize them as you want.
 
 ### Show diff between your envs files
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   "require": {
     "php": ">=7.0",
     "vlucas/phpdotenv": "~2.2",
-    "laravel/framework": "5.*"
+    "laravel/framework": "5.*",
+    "guzzlehttp/guzzle": "^6.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",

--- a/config/env-sync.php
+++ b/config/env-sync.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+
+    'slack' => [
+        /**
+         * Using the channel config you can modify the channel to which the notification is sent.
+         * This allows you to reuse slack web-hooks, create one and use it for all projects.
+         * If you want the notification to go to the default channel just leave it blank.
+         * You can specify channel like this `#general` or user like this `@john.doe`.
+         */
+        'channel' => env('ENV_SYNC_SLACK_CHANNEL'),
+
+        /**
+         * The slack web-hook url used to deliver the notification.
+         */
+        'url' => env('ENV_SYNC_SLACK_URL'),
+
+        /**
+         * The name displayed as a sender of the notification in slack.
+         */
+        'username' => 'Deployer',
+
+        /**
+         * The icon displayed as a sender of the notification in slack.
+         * You can use any slack icon here.
+         */
+        'icon' => ':boom:',
+    ],
+];

--- a/src/Console/CheckCommand.php
+++ b/src/Console/CheckCommand.php
@@ -7,7 +7,10 @@
 
 namespace Jtant\LaravelEnvSync\Console;
 
+use Illuminate\Support\Facades\Notification;
 use Jtant\LaravelEnvSync\SyncService;
+use Jtant\LaravelEnvSync\Notifications\SlackChannel;
+use Jtant\LaravelEnvSync\Notifications\MissingEnvVariables;
 
 class CheckCommand extends BaseCommand
 {
@@ -16,7 +19,7 @@ class CheckCommand extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'env:check {--src=} {--dest=} {--reverse}';
+    protected $signature = 'env:check {--src=} {--dest=} {--reverse} {--notifySlack}';
 
     /**
      * The console command description.
@@ -71,6 +74,10 @@ class CheckCommand extends BaseCommand
         }
 
         $this->info(sprintf("You can use `php artisan env:sync%s` to synchronise them", $this->option('reverse') ? ' --reverse' : ''));
+
+        if ($this->option('notifySlack')) {
+            Notification::send(new SlackChannel, new MissingEnvVariables($diffs));
+        }
 
         return 1;
     }

--- a/src/EnvSyncServiceProvider.php
+++ b/src/EnvSyncServiceProvider.php
@@ -22,7 +22,9 @@ class EnvSyncServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->publishes([
+            __DIR__ . '/../config/env-sync.php' => config_path('env-sync.php'),
+        ]);
     }
 
     /**
@@ -32,6 +34,8 @@ class EnvSyncServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__ . '/../config/env-sync.php', 'env-sync');
+
         // bindings
         $this->app->bind(ReaderInterface::class, EnvFileReader::class);
         $this->app->bind(WriterInterface::class, EnvFileWriter::class);
@@ -49,6 +53,4 @@ class EnvSyncServiceProvider extends ServiceProvider
             WriterInterface::class,
         ];
     }
-
-
 }

--- a/src/Notifications/MissingEnvVariables.php
+++ b/src/Notifications/MissingEnvVariables.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Jtant\LaravelEnvSync\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\SlackMessage;
+
+class MissingEnvVariables extends Notification
+{
+    use Queueable;
+
+    protected $missingVars;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($missingVars)
+    {
+        $this->missingVars = $missingVars;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['slack'];
+    }
+
+    /**
+     * Get the slack representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+            ->from(config('env-sync.slack.username'), config('env-sync.slack.icon'))
+            ->to(config('env-sync.slack.channel'))
+            ->error()
+            ->attachment(function ($attachment) {
+                return $attachment
+                    ->title('Whoops! You are missing some env variables on the server.')
+                    ->content(implode("\n", array_keys($this->missingVars)));
+            });
+    }
+}

--- a/src/Notifications/SlackChannel.php
+++ b/src/Notifications/SlackChannel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jtant\LaravelEnvSync\Notifications;
+
+use Illuminate\Notifications\Notifiable;
+
+class SlackChannel
+{
+    use Notifiable;
+
+    /**
+     * Route notifications for the Slack channel.
+     *
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return string
+     */
+    public function routeNotificationForSlack($notification)
+    {
+        return config('env-sync.slack.url');
+    }
+}


### PR DESCRIPTION
This might be usefull when making automatic deployments, for example using `envoy`.
There might be a line at the end of the deployment script, that runs `php artisan env:check --notifySlack` and in case of any missing variables, to send slack notification to some channel, so we can fix it quickly.