### PR TITLE
Only require the illuminate packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   "require": {
     "php": ">=7.0",
     "vlucas/phpdotenv": "~2.2",
-    "laravel/framework": "5.*"
+    "illuminate/console": "5.*",
+    "illuminate/support": "5.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
Switching the dependency requirement from laravel/framework to illuminate/support & illuminate/console will allow the package to be used with Lumen.