### PR TITLE
Fire event when env variables are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The command simply show you which keys are not present in your .env file. This c
 
 Again, you can launch the command with the option `--reverse` or with `--src` and `--dest`.
 
+The command will also dispatch event `Jtant\LaravelEnvSync\Events\MissingEnvVars`, which will contain the missing env variables, which could be used in automatic deployments. Event is only fired when there are missing env variables.
+
 ### Show diff between your envs files
 
 You can show a table that compares the content of your env files by using the `php artisan env:diff` command.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "php": ">=7.1",
     "vlucas/phpdotenv": "3.*",
     "illuminate/console": "5.*|^6.0",
-    "illuminate/support": "5.*|^6.0"
+    "illuminate/support": "5.*|^6.0",
+    "illuminate/events": "5.*|^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5|^8.3",

--- a/src/Console/CheckCommand.php
+++ b/src/Console/CheckCommand.php
@@ -7,6 +7,7 @@
 
 namespace Jtant\LaravelEnvSync\Console;
 
+use Jtant\LaravelEnvSync\Events\MissingEnvVars;
 use Jtant\LaravelEnvSync\SyncService;
 
 class CheckCommand extends BaseCommand
@@ -61,6 +62,8 @@ class CheckCommand extends BaseCommand
             $this->info(sprintf("Your %s file is already in sync with %s", basename($dest), basename($src)));
             return 0;
         }
+
+        MissingEnvVars::dispatch($diffs);
 
         $this->info(sprintf("The following variables are not present in your %s file : ", basename($dest)));
         foreach ($diffs as $key => $diff) {

--- a/src/Events/MissingEnvVars.php
+++ b/src/Events/MissingEnvVars.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jtant\LaravelEnvSync\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class MissingEnvVars
+{
+    use Dispatchable;
+
+    protected $diffs;
+
+    public function __construct($diffs)
+    {
+        $this->diffs = $diffs;
+    }
+}


### PR DESCRIPTION
This PR allows us to hook when env variable is missing. This way we can listen for the event and send some notification that some env variable is missing.