### PR TITLE
Add non-zero exit status for failed diff

### DIFF
--- a/src/Console/DiffCommand.php
+++ b/src/Console/DiffCommand.php
@@ -32,6 +32,11 @@ class DiffCommand extends BaseCommand
      */
     private $reader;
 
+    /**
+     * @var int
+     */
+    private $returnCode = 0;
+
 
     /**
      * Create a new command instance.
@@ -62,11 +67,20 @@ class DiffCommand extends BaseCommand
         $header = ["Key", basename($dest), basename($src)];
         $lines = [];
         foreach ($keys as $key) {
-            $envVal = isset($envValues[$key]) ? $envValues[$key] : '<error>NOT FOUND</error>';
-            $exampleVal = isset($exampleValues[$key]) ? $exampleValues[$key] : '<error>NOT FOUND</error>';
+            $envVal = isset($envValues[$key]) ? $envValues[$key] : $this->errorText();
+            $exampleVal = isset($exampleValues[$key]) ? $exampleValues[$key] : $this->errorText();
             $lines[] = [$key, $envVal, $exampleVal];
         }
 
         $this->table($header, $lines);
+
+        return $this->returnCode;
+    }
+
+    private function errorText()
+    {
+        $this->returnCode = 1;
+
+        return '<error>NOT FOUND</error>';
     }
 }

--- a/tests/Console/DiffCommandTest.php
+++ b/tests/Console/DiffCommandTest.php
@@ -35,7 +35,7 @@ class DiffCommandTest extends TestCase
         $this->app->setBasePath($root->url());
 
         // Act
-        Artisan::call('env:diff', []);
+        $returnCode = Artisan::call('env:diff', []);
 
         // Assert
 
@@ -51,5 +51,6 @@ class DiffCommandTest extends TestCase
 TAG;
 
         $this->assertEquals($expected, Artisan::output());
+        $this->assertSame(1, (int)$returnCode);
     }
 }


### PR DESCRIPTION
I noticed that `env:diff` still returned `0` even if there were differences between the env files.