### PR TITLE
Laravel 7.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
   },
   "require": {
     "php": ">=7.1",
-    "vlucas/phpdotenv": "3.*",
-    "illuminate/console": "5.*|^6.0",
-    "illuminate/support": "5.*|^6.0",
-    "illuminate/events": "5.*|^6.0"
+    "vlucas/phpdotenv": "^4.0",
+    "illuminate/console": "^7.0",
+    "illuminate/support": "^7.0",
+    "illuminate/events": "^7.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5|^8.3",
+    "phpunit/phpunit": "^8.3",
     "mikey179/vfsstream": "^1.6",
     "mockery/mockery": "^1.0",
-    "orchestra/testbench": "~3.8|^4.0"
+    "orchestra/testbench": "^5.0"
   },
   "license": "MIT",
   "authors": [

--- a/src/Reader/File/EnvFileReader.php
+++ b/src/Reader/File/EnvFileReader.php
@@ -7,7 +7,8 @@
 
 namespace Jtant\LaravelEnvSync\Reader\File;
 
-use Dotenv\Environment\DotenvFactory;
+use Dotenv\Store\File\Reader;
+use Illuminate\Support\Env;
 use Jtant\LaravelEnvSync\Reader\ReaderInterface;
 
 class EnvFileReader implements ReaderInterface
@@ -27,6 +28,8 @@ class EnvFileReader implements ReaderInterface
             throw new FileRequired();
         }
 
-        return (new \Dotenv\Loader([$resource], new DotenvFactory(), true))->load();
+        $files = Reader::read([$resource], true);
+
+        return (new \Dotenv\Loader\Loader())->load(Env::getRepository(), reset($files));
     }
 }

--- a/src/Reader/File/Loader.php
+++ b/src/Reader/File/Loader.php
@@ -7,21 +7,25 @@
 
 namespace Jtant\LaravelEnvSync\Reader\File;
 
-use Dotenv\Loader as OriginalLoader;
+use Dotenv\Loader\Loader as OriginalLoader;
+use Dotenv\Repository\RepositoryInterface;
 
 class Loader extends OriginalLoader
 {
     /**
      * Load `.env` file in given directory.
      *
+     * @param RepositoryInterface $repository
+     * @param string              $content
+     *
      * @return array
      */
-    public function load()
+    public function load(RepositoryInterface $repository, $content)
     {
         $this->ensureFileIsReadable();
 
         $filePath = $this->filePath;
-        $lines = $this->readLinesFromFile($filePath);
+        $lines    = $this->readLinesFromFile($filePath);
 
         $finalLines = [];
         foreach ($lines as $line) {

--- a/tests/Writer/File/EnvFileWriteTest.php
+++ b/tests/Writer/File/EnvFileWriteTest.php
@@ -39,17 +39,6 @@ class EnvFileWriterTest extends TestCase
     /** @test */
     public function it_should_append_content_to_file()
     {
-        app()->instance(\Illuminate\Contracts\Debug\ExceptionHandler::class, new class extends \Illuminate\Foundation\Exceptions\Handler {
-            public function __construct() {}
-            public function report(\Exception $e) {}
-            public function render($request, \Exception $e)
-            {
-                echo $e->getMessage();
-                throw $e;
-            }
-        });
-
-
         // Arrange
         $filePath = $this->fs->url() . '/.env';
 


### PR DESCRIPTION
Adds support for Laravel 7.0

PhpDotenv 4.0 contains some breaking changes, therefor it's not really possible to keep maintaining old versions at the same time. I'd suggest a new major version of this package to account for that.